### PR TITLE
Fix attribute values in composer.json

### DIFF
--- a/ops/configuration/php-conf/composer.json.dist
+++ b/ops/configuration/php-conf/composer.json.dist
@@ -1,7 +1,7 @@
 {
-    "name": "GigaDB (${COMPOSER_WARNING})",
-    "type": "Yii-based web site",
-    "description": "GigaDB primarily serves as a repository to host data and tools associated with articles in GigaScience journal",
+    "name": "gigascience/gigadb-website",
+    "type": "yii-project",
+    "description": "GigaDB primarily serves as a repository to host data and tools associated with articles in GigaScience journal. (${COMPOSER_WARNING})",
     "homepage": "http://gigadb.org",
     "require": {
         "php": "^${PHP_VERSION}",

--- a/ops/configuration/php-conf/composer.json.dist
+++ b/ops/configuration/php-conf/composer.json.dist
@@ -11,13 +11,13 @@
         "gabrielelana/byte-units": "^0.5",
         "google/apiclient": "v2.2.2",
         "suin/php-rss-writer": "^1.6",
-         "leafo/lessphp": "^v0.3.9",
-         "opauth/opauth": "^0.4.5",
-         "opauth/facebook": "^0.4.2",
-         "opauth/twitter": "^0.3.2",
-         "opauth/google": "^0.2.2",
-         "opauth/linkedin": "^0.2.0",
-         "drewm/mailchimp-api": "^v2.5"
+        "leafo/lessphp": "^v0.3.9",
+        "opauth/opauth": "^0.4.5",
+        "opauth/facebook": "^0.4.2",
+        "opauth/twitter": "^0.3.2",
+        "opauth/google": "^0.2.2",
+        "opauth/linkedin": "^0.2.0",
+        "drewm/mailchimp-api": "^v2.5"
     },
     "require-dev": {
         "behat/behat":  "^3.5",


### PR DESCRIPTION
# Pull request for issue: gigascience/gigadb-website#361

This is a pull request to fix problems with the `name` and `type` attributes in `composer.json`.

## Changes to the provisioning

When running `docker-compose run --rm webapp`, a `JsonValidationException` message appears because the `type` attribute does not match the regex pattern `^[a-z0-9-]+$`. Attribute value for `type` now changed to `yii-project`.

The package name was invalid so the attribute value for `name` is now `gigascience/gigadb-website`
