### PR TITLE
Dataset backup tool on handling file permission issues 

### DIFF
--- a/gigadb/app/tools/dataset-backup-tool/README.md
+++ b/gigadb/app/tools/dataset-backup-tool/README.md
@@ -83,7 +83,7 @@ we need to:
 The latter file is git-ignored and is created from example ``gigadb/app/tools/dataset-backup-tool/config/variables.example`` by copying it:
 ```
 $ cd gigadb/app/tools/dataset-backup-tool
-$ cp config/variables.example config/variable
+$ cp config/variables.example config/variables
 ```
 The default values from the example should work for testing purpose.
 

--- a/gigadb/app/tools/dataset-backup-tool/README.md
+++ b/gigadb/app/tools/dataset-backup-tool/README.md
@@ -121,6 +121,50 @@ $ docker-compose run --rm backup_tool /app/scripts/sync_files.sh --verbose
 
 >**Note 2:** the deletion script is more interactive as it prompts the user for the file to delete and then ask for confirmation.
 
+## Tools for GigaDB: To handle file permission issues [#684](https://github.com/gigascience/gigadb-website/issues/684)
+
+In `cngb-gigadb-bak` server, to identify the permission of the files that is `not globally readable` in `/data/gigadb/pub/10.5524/` we could use:
+```
+$ find /data/gigadb/pub/10.5524/ ! -perm -g+r,u+r,o+r
+```
+To change the files to `globally readable`, we could use:
+```
+$ find /data/gigadb/pub/10.5524/ ! -perm -g+r,u+r,o+r -exec chmod a+r {} \;
+```
+The above is the main command to find not `globally readable` files recursively in a directory and fix it.
+
+## Smoke tests for finding and fixing the permissions
+
+### How to run the test:
+Change directory to the `dataset-backup-tool`:
+```
+$ cd gigadb/app/tools/dataset-backup-tool
+$ compose install
+```
+
+There are 3 smoke tests in `tests/functional/FixPermissionCest.php` which would
+identify and fix the permission in a mock directory `tests/_data/10.1234` :
+* `listOkFilePermissions` will identify the permission of the `tests/_data/10.1234/100001_101009/100010/perm-ok.txt` which wasd created with `-rw-r--r--`.
+
+* `listNotOkFilePermissions` will identify the permission of the `tests/_data/10.1234/100001_101009/100300/perm-not-ok.txt` which was created with `----------`.
+
+* `changeNotOkFilePermissionToOk` will identify `non globally readable` files in `tests/_data/10.1234/` and change it to `globally readable` like this `-r--r--r--`.
+
+To run these smoke tests:
+```
+$ docker-compose run --rm backup_tool ./vendor/bin/codecept run tests/functional/FixPermissionCest.php
+```
+
+###  Set up the `cronjob`:
+The permission issues could occur regularly, so a regular fixing would be needed.  
+To enable the `cronjob` which would start fixing permission at midnight of every day:
+```
+$ cd gigadb/app/tools/dataset-backup-tool
+$ crontab < cronjob_fix_permission.txt
+$ crontab -l 
+0 0 * * * /app/scripts/fix-permissions.sh >> /tmp/permission_cron.log 2>&1
+```
+
 
 
 

--- a/gigadb/app/tools/dataset-backup-tool/README.md
+++ b/gigadb/app/tools/dataset-backup-tool/README.md
@@ -140,6 +140,7 @@ Change directory to the `dataset-backup-tool`:
 ```
 $ cd gigadb/app/tools/dataset-backup-tool
 $ compose install
+$ chmod a+x scripts/perm_to_ok.sh scripts/perm_to_not_ok.sh scripts/fix_permission.sh
 ```
 
 There are 3 smoke tests in `tests/functional/FixPermissionCest.php` which would

--- a/gigadb/app/tools/dataset-backup-tool/cronjob_fix_permission.txt
+++ b/gigadb/app/tools/dataset-backup-tool/cronjob_fix_permission.txt
@@ -1,0 +1,1 @@
+0 0 * * * /app/scripts/fix-permissions.sh >> /tmp/permission_cron.log 2>&1

--- a/gigadb/app/tools/dataset-backup-tool/docker-compose.yml
+++ b/gigadb/app/tools/dataset-backup-tool/docker-compose.yml
@@ -19,4 +19,5 @@ services:
     volumes:
       - .:/app
       - ./config/rclone.conf:/root/.config/rclone/rclone.conf
+      - ./tests/_data/10.1234:/data/gigadb/pub/10.5524/
     command: ../../../../ops/scripts/webapp_setup.sh

--- a/gigadb/app/tools/dataset-backup-tool/scripts/fix_permissions.sh
+++ b/gigadb/app/tools/dataset-backup-tool/scripts/fix_permissions.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+find /data/gigadb/pub/10.5524/ ! -perm -g+r,u+r,o+r -exec chmod a+r {} \; >> /tmp/permission_cron 2>&1

--- a/gigadb/app/tools/dataset-backup-tool/scripts/perm_to_not_ok.sh
+++ b/gigadb/app/tools/dataset-backup-tool/scripts/perm_to_not_ok.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+chmod 000 tests/_data/10.1234/100001_101009/100300/perm-not-ok.txt

--- a/gigadb/app/tools/dataset-backup-tool/scripts/perm_to_ok.sh
+++ b/gigadb/app/tools/dataset-backup-tool/scripts/perm_to_ok.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+chmod 644 tests/_data/10.1234/100001_101009/100300/perm-not-ok.txt

--- a/gigadb/app/tools/dataset-backup-tool/tests/_support/BucketHelper.php
+++ b/gigadb/app/tools/dataset-backup-tool/tests/_support/BucketHelper.php
@@ -31,6 +31,7 @@ class BucketHelper extends \Codeception\Module
     {
         $this->debug("********** AFTER *********");
         try {
+            $output = shell_exec("coscmd -c ./scripts/.cos.conf delete -r -f dataset/ 2>&1");
             $output = shell_exec("scripts/delete_bucket.sh");
         }
         catch (Throwable $e) {

--- a/gigadb/app/tools/dataset-backup-tool/tests/_support/BucketHelper.php
+++ b/gigadb/app/tools/dataset-backup-tool/tests/_support/BucketHelper.php
@@ -17,7 +17,7 @@ class BucketHelper extends \Codeception\Module
     {
         $this->debug("********** BEFORE *********");
         try {
-            $output = shell_exec("scripts/create_bucket.sh");
+            $output = shell_exec("scripts/perm_to_not_ok.sh");
         }
         catch (Throwable $e) {
             $this->stdout($e->getMessage().PHP_EOL, Console::FG_RED);
@@ -31,8 +31,7 @@ class BucketHelper extends \Codeception\Module
     {
         $this->debug("********** AFTER *********");
         try {
-            $output = shell_exec("coscmd -c ./scripts/.cos.conf delete -r -f dataset/ 2>&1");
-            $output = shell_exec("scripts/delete_bucket.sh");
+            $output = shell_exec("scripts/perm_to_ok.sh");
         }
         catch (Throwable $e) {
             $this->stdout($e->getMessage().PHP_EOL, Console::FG_RED);

--- a/gigadb/app/tools/dataset-backup-tool/tests/_support/BucketHelper.php
+++ b/gigadb/app/tools/dataset-backup-tool/tests/_support/BucketHelper.php
@@ -17,7 +17,7 @@ class BucketHelper extends \Codeception\Module
     {
         $this->debug("********** BEFORE *********");
         try {
-            $output = shell_exec("scripts/perm_to_not_ok.sh");
+            $output = shell_exec("scripts/create_bucket.sh");
         }
         catch (Throwable $e) {
             $this->stdout($e->getMessage().PHP_EOL, Console::FG_RED);
@@ -31,7 +31,7 @@ class BucketHelper extends \Codeception\Module
     {
         $this->debug("********** AFTER *********");
         try {
-            $output = shell_exec("scripts/perm_to_ok.sh");
+            $output = shell_exec("scripts/delete_bucket.sh");
         }
         catch (Throwable $e) {
             $this->stdout($e->getMessage().PHP_EOL, Console::FG_RED);

--- a/gigadb/app/tools/dataset-backup-tool/tests/_support/FilePermissionHelper.php
+++ b/gigadb/app/tools/dataset-backup-tool/tests/_support/FilePermissionHelper.php
@@ -1,0 +1,33 @@
+<?php
+namespace Codeception\Module;
+
+class FilePermissionHelper extends \Codeception\Module
+{
+    public function _beforeSuite($settings = array())
+    {
+        $this->debug("********** BEFORE *********");
+        try {
+            $output = shell_exec("scripts/perm_to_not_ok.sh");
+        }
+        catch (Throwable $e) {
+            $this->stdout($e->getMessage().PHP_EOL, Console::FG_RED);
+            Yii::error($e->getMessage());
+            return ExitCode::OSERR;
+        }
+        return $output;
+    }
+
+    public function _afterSuite()
+    {
+        $this->debug("********** AFTER *********");
+        try {
+            $output = shell_exec("scripts/perm_to_ok.sh");
+        }
+        catch (Throwable $e) {
+            $this->stdout($e->getMessage().PHP_EOL, Console::FG_RED);
+            Yii::error($e->getMessage());
+            return ExitCode::OSERR;
+        }
+        return $output;
+    }
+}

--- a/gigadb/app/tools/dataset-backup-tool/tests/functional.suite.yml
+++ b/gigadb/app/tools/dataset-backup-tool/tests/functional.suite.yml
@@ -14,3 +14,4 @@ modules:
       - Asserts
       - BucketHelper
       - Cli
+      - FilePermissionHelper

--- a/gigadb/app/tools/dataset-backup-tool/tests/functional/FixPermissionCest.php
+++ b/gigadb/app/tools/dataset-backup-tool/tests/functional/FixPermissionCest.php
@@ -1,0 +1,36 @@
+<?php
+
+use yii\console\ExitCode;
+
+class FixPermissionCest
+{
+    /**
+     * list file with permission Ok
+     * dummy file created with permission -rw-r--r--
+     */
+    public function listOkFilePermissions (\FunctionalTester $I) {
+        $I->runShellCommand("ls -al /app/tests/_data/10.1234/100001_101009/100010/perm-ok.txt");
+        $output = $I->grabShellOutput();
+        $I->assertStringContainsString("-rw-r--r--", $output, "Ok file cannot be ls!");
+    }
+
+    /**
+     * list file with permission not Ok
+     * dummy file created with permission
+     */
+    public function listNotOkFilePermissions (\FunctionalTester $I) {
+        $I->runShellCommand("ls -al /app/tests/_data/10.1234/100001_101009/100300/perm-not-ok.txt");
+        $output = $I->grabShellOutput();
+        $I->assertStringContainsString("----------", $output, "Not Ok file cannot be ls!");
+    }
+
+    /**
+     * Change the file permission to Ok
+     */
+    public function changeNotOkFilePermissionToOk (\FunctionalTester $I) {
+        $I->runShellCommand("find /app/tests/_data/10.1234/ ! -perm -g+r,u+r,o+r -exec chmod a+r {} \;");
+        $I->runShellCommand("ls -al /app/tests/_data/10.1234/100001_101009/100300/perm-not-ok.txt");
+        $output = $I->grabShellOutput();
+        $I->assertStringContainsString("-r--r--r--", $output, "Not Ok file permission has not been changed!");
+    }
+}


### PR DESCRIPTION
# Pull request for issue: [#684](https://github.com/gigascience/gigadb-website/issues/684)

This is a pull request for the following functionalities:
This PR has the commands to find and fix the `non globally readable` files in the directory `/data/gigadb/pub/10.5524/` of `cngb-gigadb-bak` server.

A cronjob script `fix-permissions.sh` is created to check and fix the permission at midnight of everyday.

<Insert description of the proposed new functionalities and how they can be tested>


## Changes to the tests

<Insert description of changes to the test code>

1. Performed `smoke test` on the linux commands used to find and fix the permission issues.
2. Created beforeSuite script `perm_to_not_ok.sh` and afterSuite script `perm_to_ok.sh`.


