### PR TITLE
Dataset backup tool

### DIFF
--- a/gigadb/app/tools/dataset-backup-tool/.gitignore
+++ b/gigadb/app/tools/dataset-backup-tool/.gitignore
@@ -37,3 +37,4 @@ tests/_support/_generated
 */create_bucket.sh
 */delete_bucket.sh
 */rclone.conf
+config/variables

--- a/gigadb/app/tools/dataset-backup-tool/config/variables.example
+++ b/gigadb/app/tools/dataset-backup-tool/config/variables.example
@@ -1,0 +1,3 @@
+BACKUP_LOCAL_ROOT=/app/tests/_data/dataset1
+BACKUP_REMOTE_ROOT=/cngbdb/giga/gigadb
+BACKUP_BUCKET_FULLNAME=rijatest2-1306096270

--- a/gigadb/app/tools/dataset-backup-tool/scripts/delete_files.sh
+++ b/gigadb/app/tools/dataset-backup-tool/scripts/delete_files.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+source config/variables
+
+MODE=${1:-"--dry-run"} # default to dry-run, pass --verbose to actually do the thing
+
+echo "Enter the path to the file you want to delete (not including $BACKUP_REMOTE_ROOT):"
+read
+TARGET_FILE=$REPLY
+read -p "Are you sure you want to delete $BACKUP_REMOTE_ROOT/$TARGET_FILE? (y/n) " -n 1 -r
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    echo "..."
+    # do dangerous stuff
+    rclone $MODE delete gigadb-backup:$BACKUP_BUCKET_FULLNAME$BACKUP_REMOTE_ROOT/$TARGET_FILE
+fi
+
+

--- a/gigadb/app/tools/dataset-backup-tool/scripts/sync_files.sh
+++ b/gigadb/app/tools/dataset-backup-tool/scripts/sync_files.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+source config/variables
+
+MODE=${1:-"--dry-run"} # default to dry-run, pass --verbose to actually do the thing
+
+rclone $MODE --checksum sync $BACKUP_LOCAL_ROOT gigadb-backup:$BACKUP_BUCKET_FULLNAME$BACKUP_REMOTE_ROOT

--- a/gigadb/app/tools/dataset-backup-tool/tests/functional/RCloneCest.php
+++ b/gigadb/app/tools/dataset-backup-tool/tests/functional/RCloneCest.php
@@ -43,4 +43,16 @@ class RCloneCest {
 
     }
 
+    /**
+     * @param FunctionalTester $I
+     * @group rclone-setup
+     */
+    public function tryLoadVariables(\FunctionalTester $I) {
+       $I->canSeeFileFound("/app/config/variables");
+       $I->seeThisFileMatches("/BACKUP_LOCAL_ROOT=.+/");
+       $I->seeThisFileMatches("/BACKUP_REMOTE_ROOT=.+/");
+       $I->seeThisFileMatches("/BACKUP_BUCKET_FULLNAME=.+/");
+       $I->cantSeeInThisFile("BACKUP_BUCKET_FULLNAME=cngbdb-share-backup-2-1255501786"); # don't use production bucket on dev/CI environment
+    }
+
 }

--- a/gigadb/app/tools/dataset-backup-tool/tests/functional/RCloneCest.php
+++ b/gigadb/app/tools/dataset-backup-tool/tests/functional/RCloneCest.php
@@ -9,6 +9,10 @@ use yii\console\ExitCode;
  */
 class RCloneCest {
 
+    /**
+     * @param FunctionalTester $I
+     * @group rclone-setup
+     */
     public function trySetup(\FunctionalTester $I) {
         $I->runShellCommand("rclone config dump");
         $rcloneConfigJ = $I->grabShellOutput();
@@ -21,6 +25,10 @@ class RCloneCest {
         $I->assertEquals("DEEP_ARCHIVE",$configArray["gigadb-backup"]["storage_class"]);
     }
 
+    /**
+     * @param FunctionalTester $I
+     * @group rclone-setup
+     */
     public function tryListTestBucket(\FunctionalTester $I) {
         $I->runShellCommand("rclone lsjson gigadb-backup:");
         $listJ = $I->grabShellOutput();

--- a/gigadb/app/tools/dataset-backup-tool/tests/functional/RCloneCest.php
+++ b/gigadb/app/tools/dataset-backup-tool/tests/functional/RCloneCest.php
@@ -9,10 +9,6 @@ use yii\console\ExitCode;
  */
 class RCloneCest {
 
-    /**
-     * @param FunctionalTester $I
-     * @group rclone-setup
-     */
     public function trySetup(\FunctionalTester $I) {
         $I->runShellCommand("rclone config dump");
         $rcloneConfigJ = $I->grabShellOutput();
@@ -25,10 +21,6 @@ class RCloneCest {
         $I->assertEquals("DEEP_ARCHIVE",$configArray["gigadb-backup"]["storage_class"]);
     }
 
-    /**
-     * @param FunctionalTester $I
-     * @group rclone-setup
-     */
     public function tryListTestBucket(\FunctionalTester $I) {
         $I->runShellCommand("rclone lsjson gigadb-backup:");
         $listJ = $I->grabShellOutput();


### PR DESCRIPTION
Hi @pli888,

This is a PR implementing gigascience/gigadb-website#694.

It helps with safety by having  wrapper scripts (incremental backup and file deletion) around the workflow that default to dry-run, encourage verbosity, ask for confirmation before deleting.

They also rely on environment variables to reduce the amount of typing by operator (and hence typos and wrong values).

They are stop-gap measure as they will be replaced by proper Yii2 Console controller actions in future Sprint, but they are small and simple anyways.

I've also added a smoke test to assert existence and integrity of the file containing the environment variables.

Finally, the README has been updated with a new sub-section to the RClone section for those scripts.

This approach will also facilitate functional testing of the workflows and integration with cronjob for automation.