### PR TITLE
Amend IAM ec2 policies to provision gigadb website

### DIFF
--- a/docs/awsdocs/policy-ec2.md
+++ b/docs/awsdocs/policy-ec2.md
@@ -31,6 +31,7 @@ when using the AWS management console.
                 "ec2:ImportKeyPair",
                 "ec2:CreateKeyPair",
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateTags",
                 "sts:DecodeAuthorizationMessage"
             ],
             "Resource": "*"
@@ -40,7 +41,9 @@ when using the AWS management console.
             "Effect": "Allow",
             "Action": [
                 "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:DeleteSecurityGroup"
+                "ec2:DeleteSecurityGroup",
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:AuthorizeSecurityGroupEgress"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
Three permissions were missing in order to provision a complete infrastructure for deploying gigadb website:

* In ``NonResourceBasedPermissions`` section, I've added ``ec2:CreateTags`` as we need to create tags on every kind of resources that support taggging, not just ec2
* In ``SecurityGroupActions`` section, I've added permissions to authorize and revoke Egress settings on security groups as we need to regulate outgoing connections

