### PR TITLE
Install and apply patch for uploading xls file

### DIFF
--- a/data/dev/external_link_type.csv
+++ b/data/dev/external_link_type.csv
@@ -1,3 +1,9 @@
 id,name
 1,Additional information
 2,Genome browser
+3,Protocols.io
+4,JBrowse
+5,3D Models
+6,Code Ocean
+7,Github links
+8,USCS Tumour Map Viewer

--- a/data/dev/species.csv
+++ b/data/dev/species.csv
@@ -1,3 +1,4 @@
 id,tax_id,common_name,genbank_name,scientific_name,eol_link
 8,9238,Adelie penguin,Adelie penguin,Pygoscelis adeliae,
 20,4555,Foxtail millet,foxtail millet,Setaria italica,
+100,87676,,,Eucalyptus pauciflora,

--- a/gigadb/app/tools/excel-spreadsheet-uploader/.gitignore
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/.gitignore
@@ -1,0 +1,11 @@
+develop.zip
+bin
+configuration
+lib
+logFiles
+metadataDir
+sqlFiles
+src
+uploadDir
+*.log
+time.txt

--- a/gigadb/app/tools/excel-spreadsheet-uploader/Dockerfile
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:8
+
+RUN apt-get update -yq && \
+    apt-get install -y libarchive-tools  # Provides bsdtar
+
+VOLUME ["/tool"]
+WORKDIR /tool

--- a/gigadb/app/tools/excel-spreadsheet-uploader/Dockerfile
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/Dockerfile
@@ -1,7 +1,8 @@
 FROM openjdk:8
 
 RUN apt-get update -yq && \
-    apt-get install -y libarchive-tools  # Provides bsdtar
+    apt-get install -y patch \
+    libarchive-tools  # Provides bsdtar
 
 VOLUME ["/tool"]
 WORKDIR /tool

--- a/gigadb/app/tools/excel-spreadsheet-uploader/Excel2Database4.txt
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/Excel2Database4.txt
@@ -1,0 +1,69 @@
+diff --git a/src/Excel2Database.java b/src/Excel2Database.java
+index 8fccf2a..a5340a5 100755
+--- a/src/Excel2Database.java
++++ b/src/Excel2Database.java
+@@ -1,4 +1,4 @@
+-import java.io.BufferedInputStream;
++import java.io.BufferedInputStream;
+ import java.io.File;
+ import java.io.FileInputStream;
+ import java.io.IOException;
+@@ -1836,7 +1836,7 @@ public class Excel2Database {
+               	 System.out.println(value);
+               	
+           	 }else{
+-          	 value= cell.getStringCellValue();
++          	 value= cell.getStringCellValue().trim();
+           	 System.out.println(value);
+           	 }
+       	  
+@@ -2735,6 +2735,9 @@ public class Excel2Database {
+ 					content="ftp://climb.genomics.cn/pub/10.5524/100001_101000/doi";
+ 					//record.add(content);
+ 				}
++				else if ( content.endsWith("/") == false ) {
++				    content = content + "/" ;
++				}
+ 			}
+ 		/*	
+ 			if(attribute.equals("publication_date"))
+@@ -2862,6 +2865,7 @@ public class Excel2Database {
+ 		}
+ 
+ 		table.recordList.add(record);
++	}
+ 	
+ 	public void fillTable_author() throws SQLException {
+ 		setInsertOrder("author");
+@@ -3341,6 +3345,7 @@ public void fillTable_sample_attribute() throws SQLException, IOException{
+ 			ArrayList<String> record = new ArrayList<String>();
+ 			initRecord(record, 4);
+ 			String value = HelpFunctions.trim(attributeList[i]);
++			value = value.replace(" ", "");
+ 			record.set(index_link, value);
+ 			record.set(index_dataset_id, String.valueOf(dataset_id));
+ 			String flag= database.get_result("select id from link where dataset_id= "+ dataset_id +" and link= "+"'"+value+"'" , "id");
+@@ -3360,8 +3365,15 @@ public void fillTable_sample_attribute() throws SQLException, IOException{
+ 		String[] attributeList1 = null;
+ 		int size_number1=0;
+ 		if (content1.length() != 0) {
++            if(content1.contains(","))
++			{
+ 			attributeList1 = content1.split(",");
+ 			size_number1 = attributeList1.length;
++			}
++			else{
++				attributeList1 = content1.split(";");
++				size_number1 = attributeList1.length;
++			}
+ 		}
+ 		
+ 		
+@@ -3369,6 +3381,7 @@ public void fillTable_sample_attribute() throws SQLException, IOException{
+ 			ArrayList<String> record = new ArrayList<String>();
+ 			initRecord(record, 4);
+ 			String value = HelpFunctions.trim(attributeList1[i]);
++			value = value.replace(" ", "");
+ 			record.set(index_link, value);
+ 			record.set(index_dataset_id, String.valueOf(dataset_id));
+ 			String flag= database.get_result("select id from link where dataset_id= "+ dataset_id +" and link= "+"'"+value+"'" , "id");

--- a/gigadb/app/tools/excel-spreadsheet-uploader/README.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/README.md
@@ -1,13 +1,48 @@
 # ExceltoGigaDB
 
+## Preparation
+
+Download consultant's tool as a zip file:
 ```
-# Download consultant's tool
-curl -L -O https://github.com/gigascience/ExceltoGigaDB/archive/develop.zip
-# Unpack contents
-bsdtar --strip-components=1 -xvf develop.zip
-# Execute tool
-docker-compose run --rm uploader ./run.sh
+$ curl -L -O https://github.com/gigascience/ExceltoGigaDB/archive/develop.zip
 ```
+
+Unpack contents in zip file:
+```
+# -k stops README.md from being over-written
+$ bsdtar -k --strip-components=1 -xvf develop.zip
+```
+
+Your dev environment GigaDB website needs to be running so execute the command
+below in the root directory of your `gigadb-website` repo:
+```
+$ ./up.sh
+```
+As part of the `./up.sh` process, new data will be added into the `species` and
+`external_link_type` tables from their csv files in `data/dev` directory which 
+are required  for running the Excel upload tool.
+
+## Tool execution
+
+There is an example Excel spreadsheet file `100679newversion.xls` in the 
+`uploadDir` directory. The metadata provides information about an Eucalytpus 
+dataset which can be uploaded into your `dev` GigaDB using the commands below:
+```
+# Go to tool directory
+$ cd gigadb/app/tools/excel-spreadsheet-uploader
+$ docker-compose run --rm uploader ./run.sh
+```
+
+The tool will generated `javac.log` and `java.log` files which provide 
+information about the upload process.
+
+If the tool as successfully executed then you can see the uploaded dataset in 
+the GigaDB website. Log into your local GigaDB website with the 
+`admin@gigadb.org` account and then go to http://gigadb.gigasciencejournal.com:9170/adminDataset/update/id/701. You should see the dataset admin page for
+the new `Dataset 100679`. Also, checkout the `dataset` table in the PostgreSQL
+database.
+
+---
 
 Convert excel spreadsheet to sql file into GigaDB database
 

--- a/gigadb/app/tools/excel-spreadsheet-uploader/README.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/README.md
@@ -1,0 +1,46 @@
+# ExceltoGigaDB
+
+```
+# Download consultant's tool
+curl -L -O https://github.com/gigascience/ExceltoGigaDB/archive/develop.zip
+# Unpack contents
+bsdtar --strip-components=1 -xvf develop.zip
+# Execute tool
+docker-compose run --rm uploader ./run.sh
+```
+
+Convert excel spreadsheet to sql file into GigaDB database
+
+The folder uploadDir stores spreadsheet which prepare to import into database.
+
+The folder dataDir stores all spreadsheets which already imported into database.
+
+The folder logFile stores all datasets import log including error log (if you want to debug it).
+
+The folder sqlFile stores all datasets import sql files.
+
+The folder configuration stores all parameters including database setting, validation setting, file-format setting etc.
+
+The lib stores all jar packages which used in this project. 
+
+# How to run it
+
+## step 1
+
+`/configuration/setting.xml` set the databaseUrl, databaseUsername, databasePassword
+
+## step 2
+
+Make sure `/uploadDir` folder has the spreadsheet. e.g. 100670newversion.xls
+
+## step 3
+
+Run `/src/Main.java`
+
+## step 4
+
+Check the log file and dataDir to see whether it was successful uploaded.
+
+
+
+

--- a/gigadb/app/tools/excel-spreadsheet-uploader/README.md
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/README.md
@@ -2,8 +2,20 @@
 
 ## Preparation
 
-Download consultant's tool as a zip file:
+Your dev environment GigaDB website needs to be running so execute the command
+below in the root directory of your `gigadb-website` repo:
 ```
+$ ./up.sh
+```
+As part of the `./up.sh` process, new data will be added into the `species` and
+`external_link_type` tables from their csv files in `data/dev` directory which
+are required  for running the Excel upload tool.
+
+Next, download consultant's tool as a zip file into the 
+`excel-spreadsheet-uploader` directory:
+```
+# Go to tool directory
+$ cd gigadb/app/tools/excel-spreadsheet-uploader
 $ curl -L -O https://github.com/gigascience/ExceltoGigaDB/archive/develop.zip
 ```
 
@@ -13,23 +25,12 @@ Unpack contents in zip file:
 $ bsdtar -k --strip-components=1 -xvf develop.zip
 ```
 
-Your dev environment GigaDB website needs to be running so execute the command
-below in the root directory of your `gigadb-website` repo:
-```
-$ ./up.sh
-```
-As part of the `./up.sh` process, new data will be added into the `species` and
-`external_link_type` tables from their csv files in `data/dev` directory which 
-are required  for running the Excel upload tool.
-
 ## Tool execution
 
 There is an example Excel spreadsheet file `100679newversion.xls` in the 
 `uploadDir` directory. The metadata provides information about an Eucalytpus 
 dataset which can be uploaded into your `dev` GigaDB using the commands below:
 ```
-# Go to tool directory
-$ cd gigadb/app/tools/excel-spreadsheet-uploader
 $ docker-compose run --rm uploader ./run.sh
 ```
 

--- a/gigadb/app/tools/excel-spreadsheet-uploader/docker-compose.yml
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.7'
+services:
+  uploader:
+    build:
+      context: .
+    volumes:
+      - .:/tool

--- a/gigadb/app/tools/excel-spreadsheet-uploader/run.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Set classpath
+export PROJECT_HOME="/tool"
+export LIB_DIR="$PROJECT_HOME/lib"
+export CLASSPATH=".:$LIB_DIR/*"
+
+# Clean up previous bash script runs
+declare -a files=("./java.log" "./javac.log")
+for i in "${files[@]}"
+do
+   echo "$i"
+   if [[ -f "$i" ]]
+   then
+       echo "Deleting $i"
+       rm "$i"
+   else
+       echo "$i not found"
+   fi
+done
+
+# Compile Java source files
+javac -d $PROJECT_HOME/bin \
+  $PROJECT_HOME/src/*.java \
+  $PROJECT_HOME/src/Log/*.java \
+  $PROJECT_HOME/src/Exception/*.java \
+  $PROJECT_HOME/src/Test/*.java \
+  &> javac.log
+
+# Execute ExceltoGigaDB tool
+java -cp $CLASSPATH:$PROJECT_HOME/configuration:$PROJECT_HOME/bin Main &> java.log

--- a/gigadb/app/tools/excel-spreadsheet-uploader/run.sh
+++ b/gigadb/app/tools/excel-spreadsheet-uploader/run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Apply the patch Excel2Database4
+patch --verbose -n -p1 -i Excel2Database4.txt
+
 # Set classpath
 export PROJECT_HOME="/tool"
 export LIB_DIR="$PROJECT_HOME/lib"


### PR DESCRIPTION
# Pull request for issue: https://github.com/gigascience/gigadb-website/pull/1004

This is a pull request for the following functionalities:

<Insert description of the proposed new functionalities and how they can be tested>

```
# Make sure old image has been removed
% docker rmi excel-spreadsheet-uploader_uploader          
# Manually convert xlsx to xls format and put it  in /gigadb/app/tools/excel-spreadsheet-uploader                                                          
# Rebuild the image and see if patch is working
 % docker-compose run --rm uploader bash -c "patch -v"                                               
Creating excel-spreadsheet-uploader_uploader_run ... done
GNU patch 2.7.6
Copyright (C) 2003, 2009-2012 Free Software Foundation, Inc.
Copyright (C) 1988 Larry Wall

License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Larry Wall and Paul Eggert

# Make sure Excel2Database4.txt is existed and test applying the patch
% docker-compose run --rm uploader bash -c "patch --dry-run --verbose -n -p1 -i Excel2Database4.txt"
Creating excel-spreadsheet-uploader_uploader_run ... done
Hmm...  Looks like a unified diff to me...
The text leading up to this was:
--------------------------
|diff --git a/src/Excel2Database.java b/src/Excel2Database.java
|index 8fccf2a..a5340a5 100755
|--- a/src/Excel2Database.java
|+++ b/src/Excel2Database.java
.
.
.
.
.
.
.

--------------------------
checking file src/Excel2Database.java
Using Plan A...
done


# Make sure there is a copy of xls formatted file in /gigadb/app/tools/excel-spreadsheet-uploader/uploadDir
 % docker-compose run --rm uploader ./run.sh
```
