### PR TITLE
For: Copy readme file wasabi bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 2023-06-20
+## Unreleased
 
+- Fix #1310 and #1311: Copy readme files created by readme tool into the gigadb-datasets wasabi bucket.
 - Feat #1282: Upgraded yii1.1 version to `1.1.28`, yii2 version to `2.0.48.1`, postgreSQL engine version to `14.8`, postgreSQL client version to `14`

--- a/gigadb/app/tools/readme-generator/createReadme.sh
+++ b/gigadb/app/tools/readme-generator/createReadme.sh
@@ -167,9 +167,9 @@ function copy_to_wasabi() {
     rclone_cmd+=" >> ${LOGFILE}"
     # Execute command
     eval "${rclone_cmd}"
-    echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Executed: ${rclone_cmd}" >> "$LOGFILE"
-    # Check exit code for rclone command
+    # Get exit code for rclone command
     rclone_exit_code=$?
+    echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Executed: ${rclone_cmd}" >> "$LOGFILE"
     if [ ${rclone_exit_code} -eq 0 ]; then
       echo "$(date +'%Y/%m/%d %H:%M:%S') INFO  : Successfully copied file to Wasabi for DOI: $doi" >> "${LOGFILE}"
     else 

--- a/gigadb/app/tools/readme-generator/createReadme.sh
+++ b/gigadb/app/tools/readme-generator/createReadme.sh
@@ -151,7 +151,7 @@ function copy_to_wasabi() {
     # Continue running script if there is an error executing rclone copy
     set +e
     # Construct rclone command to copy readme file to Wasabi
-    rclone_cmd="rclone copy ${readme_file} ${doi_directory}"
+    rclone_cmd="rclone copy --s3-no-check-bucket ${readme_file} ${doi_directory}"
     if [[ $(uname -n) =~ compute ]];then
       rclone_cmd+=" --config ${BASTION_RCLONE_CONF_LOCATION}"
     else

--- a/gigadb/app/tools/readme-generator/createReadme.sh
+++ b/gigadb/app/tools/readme-generator/createReadme.sh
@@ -22,7 +22,7 @@ DEV_RCLONE_CONF_LOCATION='../wasabi-migration/config/rclone.conf'
 # Wasabi directory paths
 WASABI_DEV_DIRECTORY="wasabi:gigadb-datasets/dev/pub/10.5524"
 WASABI_STAGING_DIRECTORY="wasabi:gigadb-datasets/staging/pub/10.5524"
-WASABI_LIVE_DIRECTORY="wasabi:gigadb-datasets/staging/pub/10.5524"
+WASABI_LIVE_DIRECTORY="wasabi:gigadb-datasets/live/pub/10.5524"
 
 # Rclone copy is executed in dry run mode as default. Use --apply flag to turn 
 # off dry run mode

--- a/gigadb/app/tools/readme-generator/docker-compose.production.yml
+++ b/gigadb/app/tools/readme-generator/docker-compose.production.yml
@@ -8,13 +8,6 @@ services:
       cache_from:
         - "registry.gitlab.com/$CI_PROJECT_PATH/production_tool:$GIGADB_ENV"
     volumes:
-      # Mount source-code for development
-      - .:/app
-      - .:/logs
-      # For using classes in GigaDB models and services
-      - ../../../:/gigadb
-      # For accessing pgdmp database dumps
-      - ../../../../sql:/app/sql
       # Map host directory /home/centos/readmeFiles to /app/readmeFiles in container
       - /home/centos/readmeFiles:/app/readmeFiles
     networks:

--- a/gigadb/app/tools/readme-generator/docker-compose.production.yml
+++ b/gigadb/app/tools/readme-generator/docker-compose.production.yml
@@ -10,6 +10,9 @@ services:
     volumes:
       # Map host directory /home/centos/readmeFiles to /app/readmeFiles in container
       - /home/centos/readmeFiles:/app/readmeFiles
+    networks:
+      # Connect to db-tier network in ops/docker-compose.yml
+      - proxy-db-tier
 
   configure:
     image: rija/docker-alpine-shell-tools:1.0.1
@@ -18,3 +21,7 @@ services:
       - .:/gigadb/app/tools/readme-generator:delegated
       - ../../configurator:/gigadb/app/configurator:ro
     command: /gigadb/app/tools/readme-generator/configure
+
+networks:
+  proxy-db-tier:  # represents db-tier network in ops/docker-compose.yml
+    name: ${GIGADB_COMPOSE_PROJECT_NAME}_db-tier

--- a/gigadb/app/tools/readme-generator/docker-compose.production.yml
+++ b/gigadb/app/tools/readme-generator/docker-compose.production.yml
@@ -8,6 +8,13 @@ services:
       cache_from:
         - "registry.gitlab.com/$CI_PROJECT_PATH/production_tool:$GIGADB_ENV"
     volumes:
+      # Mount source-code for development
+      - .:/app
+      - .:/logs
+      # For using classes in GigaDB models and services
+      - ../../../:/gigadb
+      # For accessing pgdmp database dumps
+      - ../../../../sql:/app/sql
       # Map host directory /home/centos/readmeFiles to /app/readmeFiles in container
       - /home/centos/readmeFiles:/app/readmeFiles
     networks:

--- a/gigadb/app/tools/readme-generator/docker-compose.production.yml
+++ b/gigadb/app/tools/readme-generator/docker-compose.production.yml
@@ -13,6 +13,8 @@ services:
 
   configure:
     image: rija/docker-alpine-shell-tools:1.0.1
+    working_dir: /gigadb/app/tools/readme-generator
     volumes:
-      - .:/app
-    command: /app/configure
+      - .:/gigadb/app/tools/readme-generator:delegated
+      - ../../configurator:/gigadb/app/configurator:ro
+    command: /gigadb/app/tools/readme-generator/configure

--- a/gigadb/app/tools/readme-generator/docker-compose.production.yml
+++ b/gigadb/app/tools/readme-generator/docker-compose.production.yml
@@ -11,7 +11,7 @@ services:
       # Map host directory /home/centos/readmeFiles to /app/readmeFiles in container
       - /home/centos/readmeFiles:/app/readmeFiles
 
-  config:
+  configure:
     image: rija/docker-alpine-shell-tools:1.0.1
     volumes:
       - .:/app

--- a/gigadb/app/tools/readme-generator/docker-compose.yml
+++ b/gigadb/app/tools/readme-generator/docker-compose.yml
@@ -29,3 +29,4 @@ services:
 networks:
   proxy-db-tier:  # represents db-tier network in ops/docker-compose.yml
     name: ${GIGADB_COMPOSE_PROJECT_NAME}_db-tier
+    external: true

--- a/gigadb/app/tools/readme-generator/gitlab-config-build-live.yml
+++ b/gigadb/app/tools/readme-generator/gitlab-config-build-live.yml
@@ -11,11 +11,11 @@ ReadmeGeneratorBuildLive:
     FORK_VARIABLES_URL: "https://gitlab.com/api/v4/groups/3501869/variables"
     GIGADB_COMPOSE_PROJECT_NAME: $CI_PROJECT_NAME
   script:
-    - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL|GROUP_VARIABLES_URL|FORK_VARIABLES_URL)"| tee gigadb/app/tools/readme-generator/.env
+    - env | grep -iE "(GIGADB_ENV|REPO_NAME|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL|GROUP_VARIABLES_URL|FORK_VARIABLES_URL)"| tee gigadb/app/tools/readme-generator/.env
     - cd gigadb/app/tools/readme-generator
     - $LOCAL_COMPOSE run --rm configure  #run configure to create configuration file with variables from live
-    - docker-compose -f docker-compose.yml run --rm tool composer install  # install composer dependencies
-    - $LOCAL_COMPOSE build production_tool  # build production container from the production docker file
+    - $LOCAL_COMPOSE run --rm production_tool composer install # install composer dependencies
+    - $LOCAL_COMPOSE build production_tool # build production container from the production docker file
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com  # log in to Gitlab so we can push the container image there
     - docker tag ${CI_PROJECT_NAME}_production_tool:latest registry.gitlab.com/$CI_PROJECT_PATH/production_tool:$GIGADB_ENV
     - docker push registry.gitlab.com/$CI_PROJECT_PATH/production_tool:$GIGADB_ENV

--- a/gigadb/app/tools/readme-generator/gitlab-config-build-live.yml
+++ b/gigadb/app/tools/readme-generator/gitlab-config-build-live.yml
@@ -14,7 +14,7 @@ ReadmeGeneratorBuildLive:
     - env | grep -iE "(GIGADB_ENV|REPO_NAME|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL|GROUP_VARIABLES_URL|FORK_VARIABLES_URL)"| tee gigadb/app/tools/readme-generator/.env
     - cd gigadb/app/tools/readme-generator
     - $LOCAL_COMPOSE run --rm configure  #run configure to create configuration file with variables from live
-    - $LOCAL_COMPOSE run --rm production_tool composer install # install composer dependencies
+    - docker-compose -f docker-compose.yml run --rm tool composer install # install composer dependencies
     - $LOCAL_COMPOSE build production_tool # build production container from the production docker file
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com  # log in to Gitlab so we can push the container image there
     - docker tag ${CI_PROJECT_NAME}_production_tool:latest registry.gitlab.com/$CI_PROJECT_PATH/production_tool:$GIGADB_ENV

--- a/gigadb/app/tools/readme-generator/gitlab-config-build-staging.yml
+++ b/gigadb/app/tools/readme-generator/gitlab-config-build-staging.yml
@@ -11,7 +11,7 @@ ReadmeGeneratorBuildStaging:
     FORK_VARIABLES_URL: "https://gitlab.com/api/v4/groups/3501869/variables"
     GIGADB_COMPOSE_PROJECT_NAME: $CI_PROJECT_NAME
   script:
-    - env | grep -iE "(GIGADB_ENV|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL|GROUP_VARIABLES_URL|FORK_VARIABLES_URL)"| tee gigadb/app/tools/readme-generator/.env
+    - env | grep -iE "(GIGADB_ENV|REPO_NAME|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL|GROUP_VARIABLES_URL|FORK_VARIABLES_URL)"| tee gigadb/app/tools/readme-generator/.env
     - cd gigadb/app/tools/readme-generator
     - $LOCAL_COMPOSE run --rm configure  # run configure to create configuration file with variables from staging
     - docker-compose -f docker-compose.yml run --rm tool composer install  # install composer dependencies

--- a/gigadb/app/tools/readme-generator/gitlab-config-build-staging.yml
+++ b/gigadb/app/tools/readme-generator/gitlab-config-build-staging.yml
@@ -14,7 +14,7 @@ ReadmeGeneratorBuildStaging:
     - env | grep -iE "(GIGADB_ENV|REPO_NAME|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL|GROUP_VARIABLES_URL|FORK_VARIABLES_URL)"| tee gigadb/app/tools/readme-generator/.env
     - cd gigadb/app/tools/readme-generator
     - $LOCAL_COMPOSE run --rm configure  # run configure to create configuration file with variables from staging
-    - docker-compose -f docker-compose.yml run --rm tool composer install  # install composer dependencies
+    - $LOCAL_COMPOSE run --rm production_tool composer install  # install composer dependencies
     - $LOCAL_COMPOSE build production_tool  # build production container from the production docker file
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com  # log in to Gitlab so we can push the container image there
     - docker tag ${CI_PROJECT_NAME}_production_tool:latest registry.gitlab.com/$CI_PROJECT_PATH/production_tool:$GIGADB_ENV

--- a/gigadb/app/tools/readme-generator/gitlab-config-build-staging.yml
+++ b/gigadb/app/tools/readme-generator/gitlab-config-build-staging.yml
@@ -14,7 +14,7 @@ ReadmeGeneratorBuildStaging:
     - env | grep -iE "(GIGADB_ENV|REPO_NAME|PROJECT_VARIABLES_URL|MISC_VARIABLES_URL|GITLAB_PRIVATE_TOKEN|CI_PROJECT_URL|GROUP_VARIABLES_URL|FORK_VARIABLES_URL)"| tee gigadb/app/tools/readme-generator/.env
     - cd gigadb/app/tools/readme-generator
     - $LOCAL_COMPOSE run --rm configure  # run configure to create configuration file with variables from staging
-    - $LOCAL_COMPOSE run --rm production_tool composer install  # install composer dependencies
+    - docker-compose -f docker-compose.yml run --rm tool composer install  # install composer dependencies
     - $LOCAL_COMPOSE build production_tool  # build production container from the production docker file
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com  # log in to Gitlab so we can push the container image there
     - docker tag ${CI_PROJECT_NAME}_production_tool:latest registry.gitlab.com/$CI_PROJECT_PATH/production_tool:$GIGADB_ENV


### PR DESCRIPTION
This is a pull request for continue work on https://github.com/gigascience/gigadb-website/pull/1326.

This PR contains the exact content of PR https://github.com/gigascience/gigadb-website/pull/1326, with additional code changes that fix bugs in `createReadme.sh` and make the tool deployable to production environments.

## How to test?

Describe how the new functionalities can be tested by PR reviewers

Please mostly refer to https://github.com/gigascience/gigadb-website/pull/1326.

#### Preparation and test in dev testing
Please refer to https://github.com/gigascience/gigadb-website/pull/1326.

#### Instantiation of staging and live servers
Please refer to https://github.com/gigascience/gigadb-website/pull/1326.

#### Test in staging
```
% ssh -i ~/.ssh/$bastion.pem centos@$staging-bation-ip                        
Activate the web console with: systemctl enable --now cockpit.socket

Last login: Fri Aug 11 05:47:41 2023 from 218.189.31.218
[centos@ip-10-99-0-109 ~]$ ls
addConstraintsQuery.sql  addTriggerQuery.sql  check-swatch.conf  createReadme.sh   datasetUpload.sh  diskUsage  dropConstraintsQuery.sql  dropTriggerQuery.sql  logs    postUpload.sh  swatch.conf  uploadLogs
addIndexQuery.sql        backups              converted          databaseReset.sh  db-env            downloads  dropIndexQuery.sql        drop_restore.log      notify  readmeFiles    uploadDir
[centos@ip-10-99-0-109 ~]$ ls readmeFiles/
[centos@ip-10-99-0-109 ~]$ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles
[centos@ip-10-99-0-109 ~]$ ls readmeFiles/
readme_100142.txt
[centos@ip-10-99-0-109 ~]$ ls logs/
wasabi_100142_20230811_064638.log 
[centos@ip-10-99-0-109 ~]$ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles --wasabi
[centos@ip-10-99-0-109 ~]$ ls logs/
wasabi_100142_20230811_064638.log  wasabi_100142_20230811_064704.log
[centos@ip-10-99-0-109 ~]$ less logs/wasabi_100142_20230811_064704.log 
[centos@ip-10-99-0-109 ~]$ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles --wasabi --apply
centos@ip-10-99-0-109 ~]$ ls logs/
wasabi_100142_20230811_064638.log  wasabi_100142_20230811_064704.log  wasabi_100142_20230811_064836.log
[centos@ip-10-99-0-109 ~]$ cat logs/wasabi_100142_20230811_064836.log 
2023/08/11 06:48:43 INFO  : Created readme file in /home/centos/runtime/curators/readme_100142.txt
2023/08/11 06:48:44 INFO  : readme_100142.txt: Copied (new)
2023/08/11 06:48:44 INFO  : Executed: rclone copy --s3-no-check-bucket /home/centos/readmeFiles/readme_100142.txt wasabi:gigadb-datasets/staging/pub/10.5524/100001_101000/100142/ --config /home/centos/.config/rclone/rclone.conf --log-file /home/centos/logs/wasabi_100142_20230811_064836.log --log-level INFO --stats-log-level DEBUG >> /home/centos/logs/wasabi_100142_20230811_064836.log
2023/08/11 06:48:44 INFO  : Successfully copied file to Wasabi for DOI: 100142
# then login wasabi console and check if readme_100142.txt has been uploaded to gigadb-datasets/staging/pub/10.5524/100001_101000/100142/
``` 

#### Test in live
```
% ssh -i ~/.ssh/$bastion.pem centos@$live-bation-ip      
Activate the web console with: systemctl enable --now cockpit.socket

Last login: Fri Aug 11 06:36:35 2023 from 52.79.248.101
[centos@ip-10-99-0-139 ~]$ ls
addConstraintsQuery.sql  addTriggerQuery.sql  check-swatch.conf  createReadme.sh   datasetUpload.sh  diskUsage  dropConstraintsQuery.sql  dropTriggerQuery.sql  logs    postUpload.sh  swatch.conf  uploadLogs
addIndexQuery.sql        backups              converted          databaseReset.sh  db-env            downloads  dropIndexQuery.sql        drop_restore.log      notify  readmeFiles    uploadDir
[centos@ip-10-99-0-139 ~]$ ls readmeFiles/
[centos@ip-10-99-0-139 ~]$ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles
[centos@ip-10-99-0-139 ~]$ ls readmeFiles/
readme_100142.txt
[centos@ip-10-99-0-139 ~]$ 
[centos@ip-10-99-0-139 ~]$ ls logs/
wasabi_100142_20230811_074936.log
[centos@ip-10-99-0-139 ~]$ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles --wasabi
[centos@ip-10-99-0-139 ~]$ ls logs/
wasabi_100142_20230811_074936.log  wasabi_100142_20230811_075151.log
[centos@ip-10-99-0-139 ~]$ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles --wasabi --apply --use-live-data
[centos@ip-10-99-0-139 ~]$ ls logs/
wasabi_100142_20230811_074936.log  wasabi_100142_20230811_075151.log  wasabi_100142_20230811_075716.log
# then login wasabi console and check if readme_100142.txt has been uploaded to gigadb-datasets/live/pub/10.5524/100001_101000/100142/
```
<img width="1648" alt="image" src="https://github.com/pli888/gigadb-website/assets/64770635/0b7815da-6ce1-4132-a14d-6259e64b65d9">


## How have functionalities been implemented?

In `createReadme.sh`, rclone option `--s3-no-check-bucket` is included in the rclone copy commend to avoid ` Forbidden` error if the destination has not been created/existed yet.
Also in `createReadme.sh`, `rclone_exit_code=$?` is moved right after the `${rclone_cmd}`, so the status of the rclone commend status can be captured correctly, it helps in debugging.

 In dev, the `networks` section in `docker-compose.yml` has to set `external: true` explicitly, otherwise with get error: 
 ```
% docker-compose run --rm tool composer install                  
WARN[0000] a network with name deployment_db-tier exists but was not created for project "readme".
Set `external: true` to use an existing network 
network deployment_db-tier was found but has incorrect label com.docker.compose.network set to "db-tier"
```
But possibly, this is only mac (M2 chip) issue, because when building `ReadmeGeneratorBuildStaging` in gitlab pipeline, if `external: true` is included in `docker-compose.production.yml`, the pipeline will fail with error:
```
$ $LOCAL_COMPOSE run --rm configure
Network kencho-gigadb-website_db-tier declared as external, but could not be found. Please create the network manually using `docker network create kencho-gigadb-website_db-tier` and try again.
```
When `external: true` is excluded from the `docker-compose.production.yml`, the `ReadmeGeneratorBuildStaging` will pass and with the external network created. 
```
$ $LOCAL_COMPOSE run --rm configure
Creating network "kencho-gigadb-website_db-tier" with the default driver
```

Also, in order to avoid `autoload.php` not found error on production environments as below:

```
[centos@ip-10-99-0-109 ~]$ ./createReadme.sh --doi 100142 --outdir /app/readmeFiles

Warning: require(/app/vendor/autoload.php): failed to open stream: No such file or directory in /app/yii on line 14
```
The error showed that the `/app/yii` tool is unavailable for the `prduction_tool`.  The step `docker-compose -f docker-compose.yml run --rm tool composer install` is essential as it would generate a `vendor` dir inside the `/app` dir, and that `vendor` dir will be copied into the `prodction_tool` image, which then it would become available to the readme generator tool in production environment. 

Finally, updated service's names in the `gitlab-config-build-staging.yml` and `gitlab-config-build-live.yml` workflow, which should be the service found in the `docker-compose.production.yml`.

## Any issues with implementation?

None.

## Any changes to automated tests?

None.

## Any changes to documentation?

None.

## Any technical debt repayment?

None.

## Any improvements to CI/CD pipeline?

None.